### PR TITLE
ccpp/framework submodule: fix Travis standalone build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,8 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = fix_travis_standalone_build_20200111
 [submodule "ccpp/physics"]
 	path = ccpp/physics
 	url = https://github.com/climbfuji/ccpp-physics


### PR DESCRIPTION
Update `.gitmodules` and submodule pointer for `ccpp/framework` to point to @climbfuji's fix_travis_standalone_build_20200111 branch. I tested it my Mac and the ufs-weather-model compiles fine for both the dynamic and static CCPP build (using `compile.sh` for the former and `compile_cmake.sh` for the latter).

For the ccpp-framework PR, see https://github.com/NCAR/ccpp-framework/pull/248.